### PR TITLE
Fixed Arch cpu detect compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = program 
 
-PROC = $(shell uname -p)
+PROC = $(shell uname -m)
 ARCH = $(PROC)-linux
 
 ifeq ($(PROC), x86_64)


### PR DESCRIPTION
Turns out, `uname` is a bit of a mess and `uname -p` is not POSIX compliant.
The `-m` flag works for both Ubuntu and Arch / Manjaro.